### PR TITLE
Markdown formatting correction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 3.  ```sh
     hugo server
     ```
-    Run this in the root directory (`quillpad.github.io if you followed the instructions above), and open localhost:1313` in your desired browser to see the preview. Make sure to keep Hugo up-to-date as well as this repository, especially if you plan to contribute.
+    Run this in the root directory (`quillpad.github.io` if you followed the instructions above), and open `localhost:1313` in your desired browser to see the preview. Make sure to keep Hugo up-to-date as well as this repository, especially if you plan to contribute.
 4.  ```sh
     hugo
     ```


### PR DESCRIPTION
Not sure if this was intentional, but it seems you forgot some backticks (\`) after the `quillpad.github.io` and before the `localhost:1313`