### PR TITLE
Update copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 resources/_gen/
+public/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 resources/_gen/
 public/
+.hugo_build.lock

--- a/config.yaml
+++ b/config.yaml
@@ -1,19 +1,18 @@
 # Edit these
 title: Quillpad
 baseURL: https://quillpad.github.io/
-copyright: © Quillpad - 2022
 
 params:
   favicon: images/Q_centered.png
-  
+
   # These are the accent colors for the light and dark themes, respectively. You can change these to match the theme of your app.
   lightColor: '#96b23a'
   darkColor: '#a4c639'
 
   # A short description for your app, to put into meta tags
   description: An open source notes app
-  
-  # Uncomment and add in your email address if you want people to contact you that way. 
+
+  # Uncomment and add in your email address if you want people to contact you that way.
   # email: fname.lname@email.tld
 
   # A catchy tagline for your app

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,7 +7,7 @@
         <tbody>
             <tr>
                 <td><a href="{{$.Site.Params.repo}}" target="_blank" rel="noopener">GitHub</a></td>
-                <td><p>{{.Site.Copyright}}</p></td>
+                <td><p>&copy; {{ .Site.Title }} - {{ now.Year }}</p></td>
             </tr>
             {{if $.Site.Params.email}}
             <tr>


### PR DESCRIPTION
- The copyright is generated from .Site.Title and from now.Year, each time the website is generated the year will be the current year. (Each year the website should be generate in the branch gh-page)(The current copyright date is 2022 and it should be updated).
- Update .gitignore.